### PR TITLE
Improve error context output and add coverage

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/daichirata/exceref/internal/errs"
 	"github.com/daichirata/exceref/internal/exceref"
 )
 
@@ -30,22 +31,22 @@ func exportFunc(cmd *cobra.Command, args []string) error {
 
 	outDir, err := cmd.Flags().GetString("out")
 	if err != nil {
-		return err
+		return errs.Wrap(err, "get out flag")
 	}
 	format, err := cmd.Flags().GetString("format")
 	if err != nil {
-		return err
+		return errs.Wrap(err, "get format flag")
 	}
 	prefix, err := cmd.Flags().GetString("prefix")
 	if err != nil {
-		return err
+		return errs.Wrap(err, "get prefix flag")
 	}
 
 	file, err := exceref.Open(args[0])
 	if err != nil {
-		return err
+		return errs.Wrap(err, "open file")
 	}
 	defer file.Close()
 
-	return file.Export(exceref.BuildExporter(format, outDir, prefix))
+	return errs.Wrap(file.Export(exceref.BuildExporter(format, outDir, prefix)), "export sheets")
 }

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/daichirata/exceref/internal/errs"
 	"github.com/daichirata/exceref/internal/exceref"
 )
 
@@ -32,19 +33,19 @@ func generateFunc(cmd *cobra.Command, args []string) error {
 
 	outDir, err := cmd.Flags().GetString("out")
 	if err != nil {
-		return err
+		return errs.Wrap(err, "get out flag")
 	}
 	lang, err := cmd.Flags().GetString("lang")
 	if err != nil {
-		return err
+		return errs.Wrap(err, "get lang flag")
 	}
 	prefix, err := cmd.Flags().GetString("prefix")
 	if err != nil {
-		return err
+		return errs.Wrap(err, "get prefix flag")
 	}
 	templatePath, err := cmd.Flags().GetString("template")
 	if err != nil {
-		return err
+		return errs.Wrap(err, "get template flag")
 	}
 
 	option := exceref.GenerateOption{
@@ -55,9 +56,9 @@ func generateFunc(cmd *cobra.Command, args []string) error {
 
 	file, err := exceref.Open(args[0])
 	if err != nil {
-		return err
+		return errs.Wrap(err, "open file")
 	}
 	defer file.Close()
 
-	return file.Generate(exceref.BuildGenerator(lang, option))
+	return errs.Wrap(file.Generate(exceref.BuildGenerator(lang, option)), "generate models")
 }

--- a/cmd/meta/export.go
+++ b/cmd/meta/export.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/daichirata/exceref/internal/errs"
 	"github.com/daichirata/exceref/internal/exceref"
 )
 
@@ -28,14 +29,14 @@ func exportFunc(cmd *cobra.Command, args []string) error {
 
 	outDir, err := cmd.Flags().GetString("out")
 	if err != nil {
-		return err
+		return errs.Wrap(err, "get out flag")
 	}
 
 	file, err := exceref.Open(args[0])
 	if err != nil {
-		return err
+		return errs.Wrap(err, "open file")
 	}
 	defer file.Close()
 
-	return file.ExportMetadata(outDir)
+	return errs.Wrap(file.ExportMetadata(outDir), "export metadata")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 
@@ -10,8 +12,9 @@ import (
 var debug bool
 
 var rootCmd = &cobra.Command{
-	Use:          "exceref",
-	SilenceUsage: true,
+	Use:           "exceref",
+	SilenceUsage:  true,
+	SilenceErrors: true,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		if debug {
 			slog.SetDefault(slog.New(
@@ -30,6 +33,17 @@ func init() {
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
+		printErrorChain(err)
 		os.Exit(1)
+	}
+}
+
+func printErrorChain(err error) {
+	fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+
+	cause := errors.Unwrap(err)
+	for cause != nil {
+		fmt.Fprintf(os.Stderr, "Caused by: %s\n", cause)
+		cause = errors.Unwrap(cause)
 	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"errors"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	apperrs "github.com/daichirata/exceref/internal/errs"
+)
+
+func TestPrintErrorChain(t *testing.T) {
+	t.Parallel()
+
+	base := errors.New("base failure")
+	err := apperrs.Wrap(apperrs.Wrap(base, "inner op"), "outer op")
+
+	prevStderr := os.Stderr
+	r, w, pipeErr := os.Pipe()
+	require.NoError(t, pipeErr)
+	os.Stderr = w
+	t.Cleanup(func() {
+		os.Stderr = prevStderr
+		_ = r.Close()
+	})
+
+	printErrorChain(err)
+
+	require.NoError(t, w.Close())
+	out, readErr := io.ReadAll(r)
+	require.NoError(t, readErr)
+
+	s := string(out)
+	require.Contains(t, s, "Error: outer op (")
+	require.Contains(t, s, "Caused by: inner op (")
+	require.Contains(t, s, "Caused by: base failure")
+}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/daichirata/exceref/internal/errs"
 	"github.com/daichirata/exceref/internal/exceref"
 )
 
@@ -24,15 +25,15 @@ func updateFunc(cmd *cobra.Command, args []string) error {
 
 	file, err := exceref.Open(args[0])
 	if err != nil {
-		return err
+		return errs.Wrap(err, "open file")
 	}
 	defer file.Close()
 
 	if err := file.UpdateReferenceData(); err != nil {
-		return err
+		return errs.Wrap(err, "update reference data")
 	}
 	if err := file.UpdateDataValidations(); err != nil {
-		return err
+		return errs.Wrap(err, "update data validations")
 	}
-	return file.Save()
+	return errs.Wrap(file.Save(), "save file")
 }

--- a/internal/errs/errs.go
+++ b/internal/errs/errs.go
@@ -1,0 +1,39 @@
+package errs
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+)
+
+type Error struct {
+	Op   string
+	File string
+	Line int
+	Err  error
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("%s (%s:%d)", e.Op, e.File, e.Line)
+}
+
+func (e *Error) Unwrap() error {
+	return e.Err
+}
+
+func Wrap(err error, op string) error {
+	if err == nil {
+		return nil
+	}
+	_, file, line, ok := runtime.Caller(1)
+	if !ok {
+		file = "unknown"
+		line = 0
+	}
+	return &Error{
+		Op:   op,
+		File: filepath.Base(file),
+		Line: line,
+		Err:  err,
+	}
+}

--- a/internal/errs/errs_test.go
+++ b/internal/errs/errs_test.go
@@ -1,0 +1,32 @@
+package errs_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/daichirata/exceref/internal/errs"
+)
+
+func TestWrap_Nil(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, errs.Wrap(nil, "noop"))
+}
+
+func TestWrap_WithCallerAndUnwrap(t *testing.T) {
+	t.Parallel()
+
+	base := errors.New("base error")
+	err := errs.Wrap(base, "test op")
+
+	var wrapped *errs.Error
+	require.ErrorAs(t, err, &wrapped)
+	require.Equal(t, "test op", wrapped.Op)
+	require.Equal(t, "errs_test.go", wrapped.File)
+	require.Greater(t, wrapped.Line, 0)
+	require.Equal(t, base, errors.Unwrap(err))
+	require.True(t, strings.Contains(err.Error(), "test op (errs_test.go:"))
+}

--- a/internal/exceref/exporter.go
+++ b/internal/exceref/exporter.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/daichirata/exceref/internal/errs"
 	"gopkg.in/yaml.v3"
 )
 
@@ -41,7 +42,7 @@ type csvExporter struct {
 func (e *csvExporter) Export(sheet *Sheet) error {
 	f, err := os.Create(filepath.Join(e.outDir, e.prefix+sheet.Name+".csv"))
 	if err != nil {
-		return err
+		return errs.Wrap(err, "create csv file")
 	}
 	defer f.Close()
 
@@ -60,19 +61,19 @@ func (e *csvExporter) Export(sheet *Sheet) error {
 		headers[i] = column.Name
 	}
 	if err := writer.Write(headers); err != nil {
-		return err
+		return errs.Wrap(err, "write csv header")
 	}
 	for _, row := range sheet.Rows {
 		records := make([]string, len(columns))
 		for i, column := range columns {
 			value, err := e.toCSVString(row[column.Index].Value)
 			if err != nil {
-				return err
+				return errs.Wrap(err, "format csv value")
 			}
 			records[i] = value
 		}
 		if err := writer.Write(records); err != nil {
-			return err
+			return errs.Wrap(err, "write csv row")
 		}
 	}
 	writer.Flush()
@@ -105,11 +106,11 @@ type jsonExporter struct {
 func (e *jsonExporter) Export(sheet *Sheet) error {
 	f, err := os.Create(filepath.Join(e.outDir, e.prefix+sheet.Name+".json"))
 	if err != nil {
-		return err
+		return errs.Wrap(err, "create json file")
 	}
 	defer f.Close()
 
-	return json.NewEncoder(f).Encode(sheet.Map())
+	return errs.Wrap(json.NewEncoder(f).Encode(sheet.Map()), "encode json")
 }
 
 func NewYAMLExporter(outDir, prefix string) *yamlExporter {
@@ -127,9 +128,9 @@ type yamlExporter struct {
 func (e *yamlExporter) Export(sheet *Sheet) error {
 	f, err := os.Create(filepath.Join(e.outDir, e.prefix+sheet.Name+".yaml"))
 	if err != nil {
-		return err
+		return errs.Wrap(err, "create yaml file")
 	}
 	defer f.Close()
 
-	return yaml.NewEncoder(f).Encode(sheet.Map())
+	return errs.Wrap(yaml.NewEncoder(f).Encode(sheet.Map()), "encode yaml")
 }

--- a/internal/exceref/file_test.go
+++ b/internal/exceref/file_test.go
@@ -1,0 +1,50 @@
+package exceref_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xuri/excelize/v2"
+
+	"github.com/daichirata/exceref/internal/exceref"
+)
+
+func TestFile_UpdateReferenceData_EmptyReferenceSource(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	referencePath := filepath.Join(dir, "master.xlsx")
+	targetPath := filepath.Join(dir, "target.xlsx")
+
+	referenceBook := excelize.NewFile()
+	require.NoError(t, referenceBook.SetSheetName("Sheet1", "master"))
+	require.NoError(t, referenceBook.SetSheetRow("master", "A1", &[]any{"string", "string"}))
+	require.NoError(t, referenceBook.SetSheetRow("master", "A2", &[]any{"code", "label"}))
+	require.NoError(t, referenceBook.SetSheetRow("master", "A3", &[]any{"", ""}))
+	require.NoError(t, referenceBook.SaveAs(referencePath))
+	require.NoError(t, referenceBook.Close())
+
+	targetBook := excelize.NewFile()
+	require.NoError(t, targetBook.SetSheetName("Sheet1", exceref.ReferenceDefinitionSheetName))
+	require.NoError(t, targetBook.SetSheetRow(
+		exceref.ReferenceDefinitionSheetName,
+		"A1",
+		&[]any{"sheet", "column", "reference_file", "reference_sheet", "reference_key", "reference_value", "reference_name"},
+	))
+	require.NoError(t, targetBook.SetSheetRow(
+		exceref.ReferenceDefinitionSheetName,
+		"A2",
+		&[]any{"", "", "master.xlsx", "master", "code", "label", "MasterCodes"},
+	))
+	require.NoError(t, targetBook.SaveAs(targetPath))
+	require.NoError(t, targetBook.Close())
+
+	file, err := exceref.Open(targetPath)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, file.Close())
+	})
+
+	require.NoError(t, file.UpdateReferenceData())
+}

--- a/internal/exceref/generator.go
+++ b/internal/exceref/generator.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"text/template"
 
+	"github.com/daichirata/exceref/internal/errs"
 	"github.com/gobuffalo/flect"
 	"github.com/iancoleman/strcase"
 	"github.com/jinzhu/inflection"
@@ -81,16 +82,16 @@ func (g *generator) Generate(sheet *Sheet) error {
 
 	templateBody, err := os.ReadFile(g.option.TemplatePath)
 	if err != nil {
-		return err
+		return errs.Wrap(err, "read template file")
 	}
 	tpl := template.Must(template.New("").Funcs(funcMap).Parse(string(templateBody)))
 
 	buf := new(bytes.Buffer)
 	if err := tpl.Execute(buf, data); err != nil {
-		return err
+		return errs.Wrap(err, "execute template")
 	}
 	if err := os.WriteFile(filepath.Join(g.option.OutDir, strcase.ToCamel(inflection.Singular(name))+".gen"), buf.Bytes(), 0644); err != nil {
-		return err
+		return errs.Wrap(err, "write generated file")
 	}
 	return nil
 }
@@ -140,20 +141,20 @@ func (g *goGenerator) Generate(sheet *Sheet) error {
 
 	templateBody, err := os.ReadFile(g.option.TemplatePath)
 	if err != nil {
-		return err
+		return errs.Wrap(err, "read template file")
 	}
 	tpl := template.Must(template.New("").Funcs(funcMap).Parse(string(templateBody)))
 
 	buf := new(bytes.Buffer)
 	if err := tpl.Execute(buf, data); err != nil {
-		return err
+		return errs.Wrap(err, "execute template")
 	}
 	src, err := format.Source(buf.Bytes())
 	if err != nil {
-		return err
+		return errs.Wrap(err, "format generated source")
 	}
 	if err := os.WriteFile(filepath.Join(g.option.OutDir, name+".gen.go"), src, 0644); err != nil {
-		return err
+		return errs.Wrap(err, "write generated go file")
 	}
 	return nil
 }
@@ -238,16 +239,16 @@ func (g *csharpGenerator) Generate(sheet *Sheet) error {
 
 	templateBody, err := os.ReadFile(g.option.TemplatePath)
 	if err != nil {
-		return err
+		return errs.Wrap(err, "read template file")
 	}
 	tpl := template.Must(template.New("").Funcs(funcMap).Parse(string(templateBody)))
 
 	buf := new(bytes.Buffer)
 	if err := tpl.Execute(buf, data); err != nil {
-		return err
+		return errs.Wrap(err, "execute template")
 	}
 	if err := os.WriteFile(filepath.Join(g.option.OutDir, strcase.ToCamel(inflection.Singular(name))+".cs"), buf.Bytes(), 0644); err != nil {
-		return err
+		return errs.Wrap(err, "write generated csharp file")
 	}
 	return nil
 }

--- a/internal/exceref/reference.go
+++ b/internal/exceref/reference.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+
+	"github.com/daichirata/exceref/internal/errs"
 )
 
 type ReferenceDefinition struct {
@@ -96,13 +98,13 @@ func (r *ReferenceResolver) References() ([]*Reference, error) {
 	for i, referenceDefinition := range r.ReferenceDefinitions {
 		referenceSheet, err := r.SheetReader.Open(referenceDefinition.ReferenceFilePath(), referenceDefinition.ReferenceSheet)
 		if err != nil {
-			return nil, err
+			return nil, errs.Wrap(err, "open reference sheet")
 		}
 
 		if referenceDefinition.PolymorphicReference() {
 			k, err := referenceSheet.Column(referenceDefinition.ReferenceKey)
 			if err != nil {
-				return nil, err
+				return nil, errs.Wrap(err, "find polymorphic reference key column")
 			}
 			reference := &Reference{
 				Definition: referenceDefinition,
@@ -112,11 +114,11 @@ func (r *ReferenceResolver) References() ([]*Reference, error) {
 		} else {
 			k, err := referenceSheet.Column(referenceDefinition.ReferenceKey)
 			if err != nil {
-				return nil, err
+				return nil, errs.Wrap(err, "find reference key column")
 			}
 			v, err := referenceSheet.Column(referenceDefinition.ReferenceValue)
 			if err != nil {
-				return nil, err
+				return nil, errs.Wrap(err, "find reference value column")
 			}
 			reference := &Reference{
 				Definition:  referenceDefinition,
@@ -140,7 +142,7 @@ func (r *ReferenceResolver) References() ([]*Reference, error) {
 func (r *ReferenceResolver) Resolve(sheet *Sheet) error {
 	references, err := r.References()
 	if err != nil {
-		return err
+		return errs.Wrap(err, "load references for resolve")
 	}
 
 	// Resolve the poymorphic reference first, since poymorphic reference resolution cannot be performed
@@ -232,7 +234,7 @@ func (r *XLSXReader) Open(path string, sheet string) (*Sheet, error) {
 	}
 	file, err := Open(path)
 	if err != nil {
-		return nil, err
+		return nil, errs.Wrap(err, "open reference file")
 	}
 	r.file[path] = file
 	return file.DataSheet(sheet)


### PR DESCRIPTION
## Summary

  This PR improves error diagnosability by introducing a shared error wrapper and chained error output in CLI commands.
  It also fixes a bug where `update` could fail with `invalid cell reference` when a reference source sheet is empty, and adds tests for both behaviors.

  ## Changes

  - Added `internal/errs`
    - `errs.Wrap(err, op)` now attaches operation context plus `file:line` at the wrap point.
  - Improved CLI error output (`cmd/root.go`)
    - Prints:
      - `Error: ...`
      - `Caused by: ...` (walked through unwrap chain)
    - Enabled `SilenceErrors: true` to avoid duplicate Cobra output.
  - Replaced plain `return err` with contextual wrapping in key paths:
    - `cmd/*` (`update`, `export`, `generate`, `meta export`)
    - `internal/exceref/*` (`file`, `reference`, `exporter`, `generator`, `metadata`)
  - Fixed empty-reference bug in `internal/exceref/file.go`
    - When `len(keys) == 0`, defined-name range end row is clamped to a valid row, preventing invalid cell references.